### PR TITLE
Update Android CI workflow for Gradle build

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,39 @@
+name: Android CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up JDK 11
+      uses: actions/setup-java@v4
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        cache: 'gradle'
+        
+    - name: Cache Gradle build
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper/
+          app/build
+        key: gradle-build-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+        restore-keys: |
+          gradle-build-${{ runner.os }}-
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+
+    - name: Build with Gradle
+      run: ./gradlew assembleDebug --stacktrace

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -14,10 +14,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Set up JDK 11
+    - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
-        java-version: '11'
+        java-version: '21'
         distribution: 'temurin'
         cache: 'gradle'
         


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for continuous integration (CI) of the Android project. The workflow automates the build process on pushes and pull requests to the `main` branch, ensuring that code changes are validated with every update.

Android CI workflow setup:

* Added `.github/workflows/android.yml` to define an automated CI pipeline that triggers on push and pull request events to the `main` branch.
* Configured the workflow to use Ubuntu runners, set up JDK 11 with Gradle caching, and execute the Gradle debug build as part of the CI process.